### PR TITLE
Add configuration editor

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,9 +17,13 @@ A Home Assistant Lovelace card for creating **RPG-style floor plans** with grid-
 https://github.com/eric802222/tile-floorplan-card
 Category: Lovelace
 3. Search for **Tile Floorplan Card** in HACS and install
-4. Add resource in **Lovelace → Resources**:  
+4. Add resource in **Lovelace → Resources**:
 url: /hacsfiles/tile-floorplan-card/tile-floorplan-card.js
 type: module
+
+After adding the resource, you can create the card directly from the Lovelace UI
+by selecting **Tile Floorplan Card** from the card picker. A basic editor lets yo
+u adjust grid settings and manage objects in JSON form without editing YAML.
 
 ## ⚙️ Example Configuration
 type: custom:ha-floorplan-card

--- a/tile-floorplan-card-editor.js
+++ b/tile-floorplan-card-editor.js
@@ -1,0 +1,76 @@
+class FloorplanCardEditor extends HTMLElement {
+  setConfig(config) {
+    this._config = config || {};
+    if (!this.isConnected) return;
+    this.render();
+  }
+
+  connectedCallback() {
+    this.render();
+  }
+
+  render() {
+    if (!this._config) this._config = {};
+    if (!this._config.grid) this._config.grid = {};
+    this.innerHTML = `
+      <style>
+        .form {
+          padding: 16px;
+        }
+        .form label {
+          display: block;
+          margin-top: 8px;
+        }
+        .form input,
+        .form textarea {
+          width: 100%;
+          box-sizing: border-box;
+        }
+      </style>
+      <div class="form">
+        <label>Grid Width</label>
+        <input id="grid_width" type="number" value="${this._config.grid.width || ''}">
+        <label>Grid Height</label>
+        <input id="grid_height" type="number" value="${this._config.grid.height || ''}">
+        <label>Tile Size</label>
+        <input id="grid_tile_size" type="number" value="${this._config.grid.tile_size || ''}">
+        <label>Background URL</label>
+        <input id="grid_background" type="text" value="${this._config.grid.background || ''}">
+        <label>Objects JSON</label>
+        <textarea id="objects" rows="6">${this._config.objects ? JSON.stringify(this._config.objects, null, 2) : ''}</textarea>
+      </div>
+    `;
+    this._attachListeners();
+  }
+
+  _attachListeners() {
+    this.querySelectorAll('input, textarea').forEach(el => {
+      el.addEventListener('change', () => this._valueChanged());
+    });
+  }
+
+  _valueChanged() {
+    const width = parseInt(this.querySelector('#grid_width').value || '0');
+    const height = parseInt(this.querySelector('#grid_height').value || '0');
+    const tileSize = parseInt(this.querySelector('#grid_tile_size').value || '0');
+    const background = this.querySelector('#grid_background').value || '';
+    let objects = [];
+    const objText = this.querySelector('#objects').value;
+    try {
+      objects = objText ? JSON.parse(objText) : [];
+    } catch(e) {
+      // ignore JSON errors
+    }
+    this._config = {
+      grid: {
+        width,
+        height,
+        tile_size: tileSize,
+        background,
+      },
+      objects,
+    };
+    this.dispatchEvent(new CustomEvent('config-changed', { detail: { config: this._config } }));
+  }
+}
+customElements.define('ha-floorplan-card-editor', FloorplanCardEditor);

--- a/tile-floorplan-card.js
+++ b/tile-floorplan-card.js
@@ -93,7 +93,31 @@ class FloorplanCard extends HTMLElement {
     getCardSize() {
       return 5;
     }
+
+    static async getConfigElement() {
+      await import('./tile-floorplan-card-editor.js');
+      return document.createElement('ha-floorplan-card-editor');
+    }
+
+    static getStubConfig() {
+      return {
+        grid: {
+          width: 5,
+          height: 5,
+          tile_size: 32,
+          background: ''
+        },
+        objects: []
+      };
+    }
   }
-  
+
   customElements.define("ha-floorplan-card", FloorplanCard);
-  
+
+  if (!window.customCards) window.customCards = [];
+  window.customCards.push({
+    type: "ha-floorplan-card",
+    name: "Tile Floorplan Card",
+    description: "RPG-style floor plan with clickable entities",
+  });
+


### PR DESCRIPTION
## Summary
- add `tile-floorplan-card-editor.js` with a simple form-based editor
- expose `getConfigElement` and `getStubConfig` in `tile-floorplan-card.js`
- register the card with `window.customCards`
- document the Lovelace UI card editor

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888773e8964832cbcc2aa8871431efe