### PR TITLE
Fix dynamic import path for card editor

### DIFF
--- a/tile-floorplan-card.js
+++ b/tile-floorplan-card.js
@@ -95,7 +95,7 @@ class FloorplanCard extends HTMLElement {
     }
 
     static async getConfigElement() {
-      await import('./tile-floorplan-card-editor.js');
+      await import(new URL('./tile-floorplan-card-editor.js', import.meta.url));
       return document.createElement('ha-floorplan-card-editor');
     }
 


### PR DESCRIPTION
## Summary
- fix path resolution for `tile-floorplan-card-editor.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888791c0224832ca42b9299b5448a2c