### PR TITLE
Fix HACS release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,4 +15,6 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
-          files: www/community/tile-floorplan-card/tile-floorplan-card.js 
+          files: |
+            tile-floorplan-card.js
+            tile-floorplan-card-editor.js

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,9 @@ Category: Lovelace
 url: /hacsfiles/tile-floorplan-card/tile-floorplan-card.js
 type: module
 
+HACS will also fetch `tile-floorplan-card-editor.js`, which provides the card's
+Lovelace editor interface.
+
 After adding the resource, you can create the card directly from the Lovelace UI
 by selecting **Tile Floorplan Card** from the card picker. A basic editor lets yo
 u adjust grid settings and manage objects in JSON form without editing YAML.


### PR DESCRIPTION
## Summary
- bundle `tile-floorplan-card-editor.js` with GitHub releases
- note in README that HACS also fetches the editor file

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68887b920964832c94bb2f36ab8a9255