### PR TITLE
Fix HACS download

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,4 +15,6 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
-          files: www/community/tile-floorplan-card/tile-floorplan-card.js 
+          files: |
+            tile-floorplan-card.js
+            tile-floorplan-card-editor.js

--- a/hacs.json
+++ b/hacs.json
@@ -3,6 +3,7 @@
     "render_readme": true,
     "content_in_root": true,
     "filename": "tile-floorplan-card.js",
+    "extra_files": ["tile-floorplan-card-editor.js"],
     "domains": [],
     "country": "ALL",
     "homeassistant": "2024.1.0",

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,10 @@ Category: Lovelace
 url: /hacsfiles/tile-floorplan-card/tile-floorplan-card.js
 type: module
 
+HACS will also fetch `tile-floorplan-card-editor.js`, which provides the card's
+Lovelace editor interface. The `hacs.json` manifest now lists this file so no
+manual changes are needed.
+
 After adding the resource, you can create the card directly from the Lovelace UI
 by selecting **Tile Floorplan Card** from the card picker. A basic editor lets yo
 u adjust grid settings and manage objects in JSON form without editing YAML.


### PR DESCRIPTION
## Summary
- ensure tile-floorplan-card-editor.js is listed in hacs.json
- clarify readme note about editor file

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68887b920964832c94bb2f36ab8a9255