### PR TITLE
Fix release token variable

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,4 +21,4 @@ jobs:
           files: |
             tile-floorplan-card.js
             tile-floorplan-card-editor.js
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- fix token name in release workflow to use default `GITHUB_TOKEN`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688890082dd4832c93353c90c71cb3de