### PR TITLE
Make floorplan responsive

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,7 @@ A Home Assistant Lovelace card for creating **RPG-style floor plans** with grid-
 - Conditional rendering of entity/virtual object images
 - Virtual objects (non-entity) for effects like shadows, highlights, or decorations
 - Click on entities to toggle or perform HA services
+- Responsive layout that scales to the width of its container
 
 
 ## 📦 Installation via HACS
@@ -34,7 +35,7 @@ type: custom:ha-floorplan-card
 grid:
   width: 20
   height: 15
-  tile_size: 32
+  tile_size: 32  # optional, kept for backward compatibility
   background: /local/floorplans/livingroom.png
 objects:
   - id: lamp_1

--- a/tile-floorplan-card.js
+++ b/tile-floorplan-card.js
@@ -1,7 +1,7 @@
 class FloorplanCard extends HTMLElement {
     setConfig(config) {
       if (!config.grid) {
-        throw new Error("You need to define a grid with width, height, and tile_size");
+        throw new Error("You need to define a grid with width and height");
       }
       this.config = config;
       this.attachShadow({ mode: "open" });
@@ -21,8 +21,8 @@ class FloorplanCard extends HTMLElement {
         <style>
           .floorplan {
             position: relative;
-            width: ${grid.width * grid.tile_size}px;
-            height: ${grid.height * grid.tile_size}px;
+            width: 100%;
+            aspect-ratio: ${grid.width}/${grid.height};
             background: url(${grid.background}) no-repeat;
             background-size: cover;
             image-rendering: pixelated;
@@ -53,19 +53,19 @@ class FloorplanCard extends HTMLElement {
           }
         }
   
-        const left = obj.x * grid.tile_size;
-        const top = obj.y * grid.tile_size;
-        const width = (obj.width || 1) * grid.tile_size;
-        const height = (obj.height || 1) * grid.tile_size;
+        const left = (obj.x / grid.width) * 100;
+        const top = (obj.y / grid.height) * 100;
+        const width = ((obj.width || 1) / grid.width) * 100;
+        const height = ((obj.height || 1) / grid.height) * 100;
   
         html += `
           <img src="${img}"
             class="object"
             style="
-              left:${left}px;
-              top:${top}px;
-              width:${width}px;
-              height:${height}px;
+              left:${left}%;
+              top:${top}%;
+              width:${width}%;
+              height:${height}%;
               z-index:${obj.z};
             "
             data-entity="${obj.entity_id || ""}"


### PR DESCRIPTION
## Summary
- make floorplan width responsive using CSS aspect-ratio
- position objects using percentages so they scale with the card
- document responsiveness and optional `tile_size`

## Testing
- `node --version`
- `node -e "require('./tile-floorplan-card.js')"` *(fails: HTMLElement is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6888e9304130832cad92991bdd0dff23