### PR TITLE
Fix edit mode check causing mobile editor crash

### DIFF
--- a/tile-floorplan-card.js
+++ b/tile-floorplan-card.js
@@ -13,8 +13,6 @@ class FloorplanCard extends HTMLElement {
     }
 
     _isEditMode() {
-        console.log(this._hass);
-        return true;
       return this._hass?.editMode;
     }
   
@@ -135,7 +133,7 @@ class FloorplanCard extends HTMLElement {
     }
 
     static async getConfigElement() {
-      await import(new URL('./tile-floorplan-card-editor.js', import.meta.url));
+      await import('./tile-floorplan-card-editor.js');
       return document.createElement('ha-floorplan-card-editor');
     }
 


### PR DESCRIPTION
## Summary
- fix `_isEditMode` to correctly read `hass.editMode`
- simplify editor import path for wider compatibility

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a04aec534832ca051a490df127764